### PR TITLE
add extension functions to realm objects

### DIFF
--- a/app/src/androidTest/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSourceTest.kt
+++ b/app/src/androidTest/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSourceTest.kt
@@ -1,6 +1,9 @@
 package xyz.mcnallydawes.githubmvp.data.source.user
 
 import android.support.test.runner.AndroidJUnit4
+import io.reactivex.Single
+import io.realm.Realm
+import io.realm.RealmObject
 import junit.framework.Assert.assertNotNull
 import org.junit.After
 import org.junit.Before
@@ -11,6 +14,7 @@ import xyz.mcnallydawes.githubmvp.data.model.local.User
 @RunWith(AndroidJUnit4::class)
 class UserLocalDataSourceTest {
 
+
     private lateinit var localDataSource: UserLocalDataSource
 
     @Before
@@ -20,7 +24,7 @@ class UserLocalDataSourceTest {
 
     @After
     fun tearDown() {
-        val observer = localDataSource.removeAllUsers().test()
+        val observer = localDataSource.removeAll().test()
         observer.awaitTerminalEvent()
     }
 
@@ -30,14 +34,14 @@ class UserLocalDataSourceTest {
     }
 
     @Test
-    fun testSaveUser() {
+    fun testSave() {
         val user = User()
 
         with (localDataSource) {
-            val observer = saveUser(user).test()
+            val observer = save(user).test()
             observer.awaitTerminalEvent()
 
-            val getObserver = getUser(user.username).test()
+            val getObserver = get(user.id).test()
             getObserver.awaitTerminalEvent()
             getObserver
                     .assertNoErrors()
@@ -48,14 +52,14 @@ class UserLocalDataSourceTest {
     }
 
     @Test
-    fun testSaveUsers() {
+    fun testSaveAll() {
         val users = arrayListOf(User(id = 1), User(id = 2), User(id = 3))
 
         with (localDataSource) {
-            var saveObserver = saveUsers(users).test()
+            var saveObserver = saveAll(users).test()
             saveObserver.awaitTerminalEvent()
 
-            val getObserver = getUsers(users[0].id - 1).test()
+            val getObserver = getAllUsers(users[0].id - 1).test()
             getObserver.awaitTerminalEvent()
             getObserver
                     .assertNoErrors()
@@ -78,18 +82,18 @@ class UserLocalDataSourceTest {
     }
 
     @Test
-    fun testRemoveAllUsers() {
+    fun testRemoveAll() {
         val user = User()
 
         with (localDataSource) {
-            val saveObserver = saveUser(user).test()
+            val saveObserver = save(user).test()
             saveObserver.awaitTerminalEvent()
 
-            val deleteObserver = removeAllUsers().test()
+            val deleteObserver = removeAll().test()
             deleteObserver.awaitTerminalEvent()
             deleteObserver.assertNoErrors()
 
-            val getObserver = getUsers(user.id - 1).test()
+            val getObserver = getAllUsers(user.id - 1).test()
             getObserver.awaitTerminalEvent()
             getObserver.assertNoErrors()
                     .assertValue({ users ->
@@ -99,21 +103,21 @@ class UserLocalDataSourceTest {
     }
 
     @Test
-    fun testRemoveUser() {
+    fun testRemove() {
         val user1 = User(id = 1)
         val user2 = User(id = 2)
 
         with (localDataSource) {
-            var saveObserver = saveUser(user1).test()
+            var saveObserver = save(user1).test()
             saveObserver.awaitTerminalEvent()
-            saveObserver = saveUser(user2).test()
+            saveObserver = save(user2).test()
             saveObserver.awaitTerminalEvent()
 
-            val deleteObserver = removeUser(user2.id).test()
+            val deleteObserver = remove(user2.id).test()
             deleteObserver.awaitTerminalEvent()
             deleteObserver.assertNoErrors()
 
-            val getObserver = getUsers(user1.id - 1).test()
+            val getObserver = getAllUsers(user1.id - 1).test()
             getObserver.awaitTerminalEvent()
             getObserver
                     .assertNoErrors()

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/model/local/RealmExtensions.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/model/local/RealmExtensions.kt
@@ -1,0 +1,93 @@
+package xyz.mcnallydawes.githubmvp.data.model.local
+
+import io.reactivex.Completable
+import io.reactivex.Maybe
+import io.reactivex.Single
+import io.realm.Realm
+import io.realm.RealmObject
+
+fun <T : RealmObject> T.get(id : Int) : Maybe<T> {
+    return Maybe.create {
+        val realm = Realm.getDefaultInstance()
+        var obj: T? = null
+        val objResult = realm.where(this::class.java).equalTo("id", id).findFirst()
+        if (objResult != null) obj = realm.copyFromRealm(objResult)
+        realm.close()
+        if (obj != null) it.onSuccess(obj)
+        else it.onComplete()
+    }
+}
+
+fun <T : RealmObject> T.get(id : String) : Maybe<T> {
+    return Maybe.create {
+        val realm = Realm.getDefaultInstance()
+        var obj: T? = null
+        val objResult = realm.where(this::class.java).equalTo("id", id).findFirst()
+        if (objResult != null) obj = realm.copyFromRealm(objResult)
+        realm.close()
+        if (obj != null) it.onSuccess(obj)
+        else it.onComplete()
+    }
+}
+
+fun  <T : RealmObject> T.save(): Single<T> {
+    return Single.create {
+        val realm = Realm.getDefaultInstance()
+        realm.executeTransaction { it.copyToRealmOrUpdate(this) }
+        realm.close()
+        it.onSuccess(this)
+    }
+}
+
+fun  <T : RealmObject> T.saveAll(objects : ArrayList<T>): Single<ArrayList<T>> {
+    return Single.create {
+        val realm = Realm.getDefaultInstance()
+        realm.executeTransaction {
+            it.copyToRealmOrUpdate(objects)
+        }
+        realm.close()
+        it.onSuccess(objects)
+    }
+}
+
+fun <T : RealmObject> T.delete(id: Int): Completable {
+    return Completable.create {
+        val realm = Realm.getDefaultInstance()
+        val objResult = realm.where(this::class.java).equalTo("id", id).findFirst()
+        if (objResult != null) { realm.executeTransaction { objResult.deleteFromRealm() } }
+        realm.close()
+        it.onComplete()
+    }
+}
+
+fun <T : RealmObject> T.deleteAll(): Completable {
+    return Completable.create {
+        val realm = Realm.getDefaultInstance()
+        val results = realm.where(this::class.java).findAll()
+        realm.executeTransaction { results.deleteAllFromRealm() }
+        realm.close()
+        it.onComplete()
+    }
+}
+
+fun <T : RealmObject> T.all(): Single<ArrayList<T>> {
+    return Single.create {
+        val objects = ArrayList<T>()
+        val realm = Realm.getDefaultInstance()
+        val results = realm.where(this::class.java).findAll()
+        if (results != null) objects.addAll(realm.copyFromRealm(results))
+        realm.close()
+        it.onSuccess(objects)
+    }
+}
+
+fun <T : RealmObject> T.first(): Maybe<T> {
+    return Maybe.create {
+        val realm = Realm.getDefaultInstance()
+        val obj = realm.where(this::class.java).findFirst()
+        realm.close()
+        if (obj == null) it.onComplete()
+        else it.onSuccess(obj)
+    }
+}
+

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/DataSource.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/DataSource.kt
@@ -1,0 +1,22 @@
+package xyz.mcnallydawes.githubmvp.data.source.user
+
+import io.reactivex.Completable
+import io.reactivex.Maybe
+import io.reactivex.Single
+
+interface DataSource<I, T> {
+
+    fun get(id: I) : Maybe<T>
+
+    fun getAll() : Single<ArrayList<T>>
+
+    fun save(obj : T) : Single<T>
+
+    fun saveAll(objects: ArrayList<T>) : Single<ArrayList<T>>
+
+    fun remove(id: I) : Completable
+
+    fun removeAll() : Completable
+
+}
+

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserDataSource.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserDataSource.kt
@@ -1,22 +1,10 @@
 package xyz.mcnallydawes.githubmvp.data.source.user
 
-import io.reactivex.Completable
-import io.reactivex.Maybe
 import io.reactivex.Single
 import xyz.mcnallydawes.githubmvp.data.model.local.User
 
-interface UserDataSource {
+interface UserDataSource : DataSource<Int, User> {
 
-    fun getUsers(lastUserId: Int) : Single<ArrayList<User>>
-
-    fun getUser(username: String) : Maybe<User>
-
-    fun saveUsers(users: ArrayList<User>) : Single<ArrayList<User>>
-
-    fun saveUser(user: User) : Single<User>
-
-    fun removeUser(id: Int) : Completable
-
-    fun removeAllUsers() : Completable
+    fun getAllUsers(lastUserId: Int) : Single<ArrayList<User>>
 
 }

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSource.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSource.kt
@@ -4,13 +4,13 @@ import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import io.realm.Realm
-import xyz.mcnallydawes.githubmvp.data.model.local.User
+import xyz.mcnallydawes.githubmvp.data.model.local.*
 import javax.inject.Singleton
 
 @Singleton
 class UserLocalDataSource : UserDataSource {
 
-    override fun getUsers(lastUserId: Int) : Single<ArrayList<User>> {
+    override fun getAllUsers(lastUserId: Int): Single<ArrayList<User>> {
         return Single.create {
             val users = ArrayList<User>()
             val realm = Realm.getDefaultInstance()
@@ -24,61 +24,25 @@ class UserLocalDataSource : UserDataSource {
         }
     }
 
-    override fun getUser(username: String) : Maybe<User> {
-        return Maybe.create {
-            val realm = Realm.getDefaultInstance()
-            var user: User? = null
-            val userResult = realm.where(User::class.java).equalTo("username", username).findFirst()
-            if (userResult != null) user = realm.copyFromRealm(userResult)
-            realm.close()
-            if (user != null) it.onSuccess(user)
-            else it.onComplete()
-        }
-    }
-
-    override fun saveUsers(users: ArrayList<User>) : Single<ArrayList<User>> {
+    override fun getAll() : Single<ArrayList<User>> {
         return Single.create {
+            val users = ArrayList<User>()
             val realm = Realm.getDefaultInstance()
-            realm.executeTransaction {
-                it.copyToRealmOrUpdate(users)
-            }
+            val results = realm.where(User::class.java).findAll().sort("id")
+            if (results != null) users.addAll(realm.copyFromRealm(results))
             realm.close()
             it.onSuccess(users)
         }
     }
 
-    override fun saveUser(user: User) : Single<User> {
-        return Single.create {
-            val realm = Realm.getDefaultInstance()
-            realm.executeTransaction {
-                it.copyToRealmOrUpdate(user)
-            }
-            realm.close()
-            it.onSuccess(user)
-        }
-    }
+    override fun get(id: Int) : Maybe<User> = User().get(id)
 
-    override fun removeUser(id: Int): Completable {
-        return Completable.create {
-            val realm = Realm.getDefaultInstance()
-            val user = realm.where(User::class.java).equalTo("id", id).findFirst()
-            realm.executeTransaction {
-                user?.deleteFromRealm()
-            }
-            realm.close()
-            it.onComplete()
-        }
-    }
+    override fun saveAll(objects: ArrayList<User>) : Single<ArrayList<User>> = User().saveAll(objects)
 
-    override fun removeAllUsers(): Completable {
-        return Completable.create {
-            val realm = Realm.getDefaultInstance()
-            val users = realm.where(User::class.java).findAll()
-            realm.executeTransaction {
-                users.deleteAllFromRealm()
-            }
-            realm.close()
-            it.onComplete()
-        }
-    }
+    override fun save(obj: User) : Single<User> = obj.save()
+
+    override fun remove(id: Int): Completable = User().delete(id)
+
+    override fun removeAll(): Completable = User().deleteAll()
+
 }

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserRemoteDataSource.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserRemoteDataSource.kt
@@ -11,16 +11,19 @@ import javax.inject.Singleton
 @Singleton
 class UserRemoteDataSource @Inject constructor(private val githubApi: GithubApi) : UserDataSource {
 
-    override fun getUsers(lastUserId: Int): Single<ArrayList<User>> = githubApi.getUsers(lastUserId)
+    override fun getAllUsers(lastUserId: Int): Single<ArrayList<User>> = githubApi.getUsers(lastUserId)
 
-    override fun getUser(username: String): Maybe<User> = githubApi.getUser(username)
+    override fun getAll(): Single<ArrayList<User>> = Single.error(Throwable("not implemented"))
 
-    override fun saveUsers(users: ArrayList<User>): Single<ArrayList<User>> =
+    override fun get(id: Int): Maybe<User> = githubApi.getUser(id)
+
+    override fun saveAll(objects: ArrayList<User>): Single<ArrayList<User>> =
             Single.error(Throwable("not implemented"))
 
-    override fun saveUser(user: User): Single<User> = Single.error(Throwable("not implemented"))
+    override fun save(obj: User): Single<User> = Single.error(Throwable("not implemented"))
 
-    override fun removeUser(id: Int): Completable = Completable.error(Throwable("not implemented"))
+    override fun remove(id: Int): Completable = Completable.error(Throwable("not implemented"))
 
-    override fun removeAllUsers(): Completable = Completable.error(Throwable("not implemented"))
+    override fun removeAll(): Completable = Completable.error(Throwable("not implemented"))
+
 }

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserRepository.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserRepository.kt
@@ -13,30 +13,33 @@ open class UserRepository @Inject constructor(
         private val remoteDataSource: UserDataSource
 ): UserDataSource {
 
-    override fun getUsers(lastUserId: Int): Single<ArrayList<User>> {
-        return localDataSource.getUsers(lastUserId)
+
+    override fun getAll(): Single<ArrayList<User>> {
+        return localDataSource.getAll()
+    }
+
+    override fun getAllUsers(lastUserId: Int): Single<ArrayList<User>> {
+        return localDataSource.getAllUsers(lastUserId)
                 .flatMap {
                     if (it.isEmpty()) {
-                        remoteDataSource.getUsers(lastUserId)
-                                .flatMap { localDataSource.saveUsers(it) }
+                        remoteDataSource.getAllUsers(lastUserId)
+                                .flatMap { localDataSource.saveAll(it) }
                     }
                     else Single.just(it)
                 }
     }
 
-    override fun getUser(username: String): Maybe<User> {
-        return remoteDataSource.getUser(username)
+    override fun get(id: Int): Maybe<User> = remoteDataSource.get(id)
+
+    override fun saveAll(objects: ArrayList<User>): Single<ArrayList<User>> {
+        return localDataSource.saveAll(objects)
     }
 
-    override fun saveUsers(users: ArrayList<User>): Single<ArrayList<User>> {
-        return localDataSource.saveUsers(users)
+    override fun save(obj: User): Single<User> {
+        return localDataSource.save(obj).flatMap { remoteDataSource.save(obj) }
     }
 
-    override fun saveUser(user: User): Single<User> {
-        return localDataSource.saveUser(user)
-    }
+    override fun remove(id: Int): Completable = localDataSource.remove(id)
 
-    override fun removeUser(id: Int): Completable = localDataSource.removeUser(id)
-
-    override fun removeAllUsers(): Completable = localDataSource.removeAllUsers()
+    override fun removeAll(): Completable = localDataSource.removeAll()
 }

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/github/GithubApi.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/github/GithubApi.kt
@@ -12,7 +12,7 @@ interface GithubApi {
     @GET("/users")
     fun getUsers(@Query("since") lastUserId: Int): Single<ArrayList<User>>
 
-    @GET("/users/{username}")
-    fun getUser(@Path("username") username: String): Maybe<User>
+    @GET("/users/{id}")
+    fun getUser(@Path("id") username: Int): Maybe<User>
 
 }

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/users/UsersPresenter.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/users/UsersPresenter.kt
@@ -43,7 +43,7 @@ class UsersPresenter(
         if (loading) return
 
         loading = true
-        userRepo.getUsers(lastUserId)
+        userRepo.getAllUsers(lastUserId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally {
@@ -67,7 +67,7 @@ class UsersPresenter(
 
     override fun onRefreshList() {
         view.hideList()
-        userRepo.removeAllUsers()
+        userRepo.removeAll()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({


### PR DESCRIPTION
This commit implements extension functions for any class that extends
the RealmObject class. This cleans up the code for our local data source
objects quite a lot as these functions now come for free. This means we
don't have to rewrite our get, save, and delete functionality for each
different local data class we have in their respective local data source
objects!

Unfortunately we can't subclass the RealmObject twice, so we have to
pass id values into the get and delete functions which means if one of
our realm objects doesn't have an id field the extension functions will
break.