### PR TITLE
add user detail view

### DIFF
--- a/app/src/androidTest/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSourceTest.kt
+++ b/app/src/androidTest/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSourceTest.kt
@@ -56,7 +56,7 @@ class UserLocalDataSourceTest {
         val users = arrayListOf(User(id = 1), User(id = 2), User(id = 3))
 
         with (localDataSource) {
-            var saveObserver = saveAll(users).test()
+            val saveObserver = saveAll(users).test()
             saveObserver.awaitTerminalEvent()
 
             val getObserver = getAllUsers(users[0].id - 1).test()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".userdetail.UserDetailActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/Constants.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/Constants.kt
@@ -1,0 +1,5 @@
+package xyz.mcnallydawes.githubmvp
+
+object Constants {
+    val EXTRA_USER_ID = "extra_user_id"
+}

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/model/local/RealmExtensions.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/model/local/RealmExtensions.kt
@@ -2,40 +2,42 @@ package xyz.mcnallydawes.githubmvp.data.model.local
 
 import io.reactivex.Completable
 import io.reactivex.Maybe
+import io.reactivex.Observable
 import io.reactivex.Single
 import io.realm.Realm
 import io.realm.RealmObject
 
-fun <T : RealmObject> T.get(id : Int) : Maybe<T> {
-    return Maybe.create {
+fun <T : RealmObject> T.get(id : Int) : Observable<T> {
+    return Observable.create {
         val realm = Realm.getDefaultInstance()
         var obj: T? = null
         val objResult = realm.where(this::class.java).equalTo("id", id).findFirst()
         if (objResult != null) obj = realm.copyFromRealm(objResult)
         realm.close()
-        if (obj != null) it.onSuccess(obj)
-        else it.onComplete()
+        if (obj != null) it.onNext(obj)
+        it.onComplete()
     }
 }
 
-fun <T : RealmObject> T.get(id : String) : Maybe<T> {
-    return Maybe.create {
+fun <T : RealmObject> T.get(id : String) : Observable<T> {
+    return Observable.create {
         val realm = Realm.getDefaultInstance()
         var obj: T? = null
         val objResult = realm.where(this::class.java).equalTo("id", id).findFirst()
         if (objResult != null) obj = realm.copyFromRealm(objResult)
         realm.close()
-        if (obj != null) it.onSuccess(obj)
-        else it.onComplete()
+        if (obj != null) it.onNext(obj)
+        it.onComplete()
     }
 }
 
-fun  <T : RealmObject> T.save(): Single<T> {
-    return Single.create {
+fun  <T : RealmObject> T.save(): Observable<T> {
+    return Observable.create {
         val realm = Realm.getDefaultInstance()
         realm.executeTransaction { it.copyToRealmOrUpdate(this) }
         realm.close()
-        it.onSuccess(this)
+        it.onNext(this)
+        it.onComplete()
     }
 }
 

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/model/local/User.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/model/local/User.kt
@@ -6,8 +6,24 @@ import io.realm.annotations.PrimaryKey
 import java.util.*
 
 open class User @JvmOverloads constructor(
-        @PrimaryKey var id: Int = Random().nextInt(),
-        var url: String = "url",
-        @SerializedName("login") var username: String = "username",
-        @SerializedName("avatar_url") var avatarUrl: String = "avatarUrl"
-) : RealmObject()
+        @PrimaryKey @SerializedName("id") var id: Int = Random().nextInt(),
+        @SerializedName("avatar_url") var avatarUrl: String? = null,
+        @SerializedName("location") var location : String? = null,
+        @SerializedName("login") var username: String? = null,
+        @SerializedName("name") var name: String? = null,
+        @SerializedName("url") var url: String? = null
+) : RealmObject() {
+
+    override fun equals(other: Any?): Boolean {
+        if (other is User) {
+            return other.id == id &&
+                    other.avatarUrl == avatarUrl &&
+                    other.location == location &&
+                    other.username == username &&
+                    other.name == name &&
+                    other.url == url
+        }
+        return super.equals(other)
+    }
+
+}

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/DataSource.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/DataSource.kt
@@ -2,15 +2,16 @@ package xyz.mcnallydawes.githubmvp.data.source.user
 
 import io.reactivex.Completable
 import io.reactivex.Maybe
+import io.reactivex.Observable
 import io.reactivex.Single
 
 interface DataSource<I, T> {
 
-    fun get(id: I) : Maybe<T>
+    fun get(id: I) : Observable<T>
 
     fun getAll() : Single<ArrayList<T>>
 
-    fun save(obj : T) : Single<T>
+    fun save(obj : T) : Observable<T>
 
     fun saveAll(objects: ArrayList<T>) : Single<ArrayList<T>>
 

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSource.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserLocalDataSource.kt
@@ -2,6 +2,7 @@ package xyz.mcnallydawes.githubmvp.data.source.user
 
 import io.reactivex.Completable
 import io.reactivex.Maybe
+import io.reactivex.Observable
 import io.reactivex.Single
 import io.realm.Realm
 import xyz.mcnallydawes.githubmvp.data.model.local.*
@@ -35,11 +36,11 @@ class UserLocalDataSource : UserDataSource {
         }
     }
 
-    override fun get(id: Int) : Maybe<User> = User().get(id)
+    override fun get(id: Int) : Observable<User> = User().get(id)
 
     override fun saveAll(objects: ArrayList<User>) : Single<ArrayList<User>> = User().saveAll(objects)
 
-    override fun save(obj: User) : Single<User> = obj.save()
+    override fun save(obj: User) : Observable<User> = obj.save()
 
     override fun remove(id: Int): Completable = User().delete(id)
 

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserRemoteDataSource.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/data/source/user/UserRemoteDataSource.kt
@@ -1,7 +1,7 @@
 package xyz.mcnallydawes.githubmvp.data.source.user
 
 import io.reactivex.Completable
-import io.reactivex.Maybe
+import io.reactivex.Observable
 import io.reactivex.Single
 import xyz.mcnallydawes.githubmvp.data.model.local.User
 import xyz.mcnallydawes.githubmvp.github.GithubApi
@@ -15,12 +15,24 @@ class UserRemoteDataSource @Inject constructor(private val githubApi: GithubApi)
 
     override fun getAll(): Single<ArrayList<User>> = Single.error(Throwable("not implemented"))
 
-    override fun get(id: Int): Maybe<User> = githubApi.getUser(id)
+    override fun get(id: Int): Observable<User> {
+        return Observable.create { emitter ->
+            githubApi.getUser(id)
+                    .subscribe({
+                        emitter.onNext(it)
+                        emitter.onComplete()
+                    }, {
+                        emitter.onComplete()
+                    }, {
+                        emitter.onComplete()
+                    })
+        }
+    }
 
     override fun saveAll(objects: ArrayList<User>): Single<ArrayList<User>> =
             Single.error(Throwable("not implemented"))
 
-    override fun save(obj: User): Single<User> = Single.error(Throwable("not implemented"))
+    override fun save(obj: User): Observable<User> = Observable.error(Throwable("not implemented"))
 
     override fun remove(id: Int): Completable = Completable.error(Throwable("not implemented"))
 

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/github/GithubApi.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/github/GithubApi.kt
@@ -1,6 +1,7 @@
 package xyz.mcnallydawes.githubmvp.github
 
 import io.reactivex.Maybe
+import io.reactivex.Observable
 import io.reactivex.Single
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -12,7 +13,7 @@ interface GithubApi {
     @GET("/users")
     fun getUsers(@Query("since") lastUserId: Int): Single<ArrayList<User>>
 
-    @GET("/users/{id}")
-    fun getUser(@Path("id") username: Int): Maybe<User>
+    @GET("/user/{id}")
+    fun getUser(@Path("id") id: Int): Observable<User>
 
 }

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailActivity.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailActivity.kt
@@ -1,0 +1,28 @@
+package xyz.mcnallydawes.githubmvp.userdetail
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import xyz.mcnallydawes.githubmvp.R
+import xyz.mcnallydawes.githubmvp.di.RepoInjection
+import xyz.mcnallydawes.githubmvp.utils.InjectionUtils
+
+class UserDetailActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_user_detail)
+
+        val fragment = fragmentManager.findFragmentById(R.id.fragment)
+                as UserDetailFragment? ?: UserDetailFragment.newInstance().also {
+            val transaction = fragmentManager.beginTransaction()
+            transaction.add(R.id.fragment, it)
+            transaction.commit()
+        }
+
+        val userRepo = RepoInjection.provideUserRepo(InjectionUtils.getGithubApi(this))
+        UserDetailPresenter(fragment, userRepo)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+}

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailContract.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailContract.kt
@@ -1,0 +1,35 @@
+package xyz.mcnallydawes.githubmvp.userdetail
+
+interface UserDetailContract {
+
+    interface View {
+
+        fun setPresenter(presenter : Presenter)
+
+        fun setAvatarIv(url : String)
+
+        fun setNameTv(name : String)
+
+        fun setUsernameTv(username : String)
+
+        fun setLocationTv(location : String)
+
+        fun showPreviousView()
+
+        fun showUserNotFoundError()
+
+        fun showErrorMessage(message : String)
+
+    }
+
+    interface Presenter {
+
+        fun initialize(userId : Int)
+
+        fun terminate()
+
+        fun onBackBtnClicked()
+
+    }
+
+}

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailFragment.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailFragment.kt
@@ -1,0 +1,88 @@
+package xyz.mcnallydawes.githubmvp.userdetail
+
+import android.app.Fragment
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import com.squareup.picasso.Picasso
+import kotlinx.android.synthetic.main.fragment_user_detail.*
+import xyz.mcnallydawes.githubmvp.Constants
+import xyz.mcnallydawes.githubmvp.R
+import xyz.mcnallydawes.githubmvp.utils.CircleTransform
+
+class UserDetailFragment : Fragment(), UserDetailContract.View {
+
+    private var presenter : UserDetailContract.Presenter? = null
+
+    companion object {
+        fun newInstance(): UserDetailFragment {
+            return UserDetailFragment()
+        }
+    }
+
+    override fun setPresenter(presenter: UserDetailContract.Presenter) {
+        this.presenter = presenter
+    }
+
+    override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        setHasOptionsMenu(true)
+        return inflater?.inflate(R.layout.fragment_user_detail, container, false)
+    }
+
+    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val userId = activity.intent.getIntExtra(Constants.EXTRA_USER_ID, -1)
+        presenter?.initialize(userId)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                presenter?.onBackBtnClicked()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        presenter?.terminate()
+    }
+
+    override fun setAvatarIv(url: String) {
+        Picasso.with(activity)
+                .load(url)
+                .transform(CircleTransform())
+                .error(R.drawable.octocat)
+                .into(avatarIv)
+    }
+
+    override fun setNameTv(name: String) {
+        nameTv.text = name
+    }
+
+    override fun setUsernameTv(username: String) {
+        usernameTv.text = username
+    }
+
+    override fun setLocationTv(location: String) {
+        locationTv.text = location
+    }
+
+    override fun showPreviousView() {
+        activity.finish()
+    }
+
+    override fun showUserNotFoundError() {
+        Toast.makeText(activity, "Unable to retrieve user", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun showErrorMessage(message : String) {
+        Toast.makeText(activity, message, Toast.LENGTH_SHORT).show()
+    }
+
+}

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailPresenter.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailPresenter.kt
@@ -1,0 +1,45 @@
+package xyz.mcnallydawes.githubmvp.userdetail
+
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.addTo
+import io.reactivex.schedulers.Schedulers
+import xyz.mcnallydawes.githubmvp.data.source.user.UserRepository
+
+class UserDetailPresenter(
+        private val view : UserDetailContract.View,
+        private val userRepo: UserRepository
+) : UserDetailContract.Presenter {
+
+    private val disposables = CompositeDisposable()
+
+    init {
+        view.setPresenter(this)
+    }
+
+    override fun initialize(userId : Int) {
+        userRepo.get(userId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    if (it.avatarUrl != null) view.setAvatarIv(it.avatarUrl!!)
+                    if (it.name != null) view.setNameTv(it.name!!)
+                    if (it.username != null) view.setUsernameTv(it.username!!)
+                    if (it.location != null) view.setLocationTv(it.location!!)
+                }, {
+                    view.showErrorMessage(it.localizedMessage)
+                }, {
+//                    TODO: All done, nothing to see here
+                }).addTo(disposables)
+    }
+
+    override fun terminate() {
+        disposables.clear()
+        disposables.dispose()
+    }
+
+    override fun onBackBtnClicked() {
+        view.showPreviousView()
+    }
+
+}

--- a/app/src/main/java/xyz/mcnallydawes/githubmvp/users/UsersFragment.kt
+++ b/app/src/main/java/xyz/mcnallydawes/githubmvp/users/UsersFragment.kt
@@ -1,6 +1,7 @@
 package xyz.mcnallydawes.githubmvp.users
 
 import android.app.Fragment
+import android.content.Intent
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
@@ -9,8 +10,10 @@ import android.view.ViewGroup
 import android.widget.Toast
 import com.jakewharton.rxbinding2.support.v7.widget.RxRecyclerView
 import kotlinx.android.synthetic.main.fragment_users.*
+import xyz.mcnallydawes.githubmvp.Constants
 import xyz.mcnallydawes.githubmvp.R
 import xyz.mcnallydawes.githubmvp.data.model.local.User
+import xyz.mcnallydawes.githubmvp.userdetail.UserDetailActivity
 import java.util.concurrent.TimeUnit
 
 class UsersFragment: Fragment(), UsersContract.View {
@@ -105,7 +108,9 @@ class UsersFragment: Fragment(), UsersContract.View {
     }
 
     override fun showUserView(user: User) {
-        Toast.makeText(activity, "Tapped " + user.username + ".", Toast.LENGTH_SHORT).show()
+        val intent = Intent(activity, UserDetailActivity::class.java)
+        intent.putExtra(Constants.EXTRA_USER_ID, user.id)
+        startActivity(intent)
     }
 
     override fun scrollToPosition(position: Int) {

--- a/app/src/main/res/layout/activity_user_detail.xml
+++ b/app/src/main/res/layout/activity_user_detail.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="xyz.mcnallydawes.githubmvp.userdetail.UserDetailActivity"
+    >
+
+    <FrameLayout
+        android:id="@+id/fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_user_detail.xml
+++ b/app/src/main/res/layout/fragment_user_detail.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+    <ImageView
+        android:id="@+id/avatarIv"
+        android:layout_width="256dp"
+        android:layout_height="256dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"
+        android:clickable="false"
+        android:focusable="false"
+        tools:background="@color/colorAccent"
+        />
+
+    <TextView
+        android:id="@+id/nameTv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/avatarIv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"
+        android:textColor="@color/colorText"
+        android:textSize="18sp"
+        tools:text="Jeffrey McNally-Dawes"
+        />
+
+    <TextView
+        android:id="@+id/usernameTv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/nameTv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:textColor="@color/colorText"
+        android:textSize="13sp"
+        tools:text="\@jeffmcnd"
+        />
+
+    <TextView
+        android:id="@+id/locationTv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/usernameTv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:textColor="@color/colorText"
+        android:textSize="13sp"
+        tools:text="San Francisco, CA"
+        />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/test/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailPresenterTest.kt
+++ b/app/src/test/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailPresenterTest.kt
@@ -1,0 +1,62 @@
+package xyz.mcnallydawes.githubmvp.userdetail
+
+import io.reactivex.Observable
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import xyz.mcnallydawes.githubmvp.RxImmediateSchedulerRule
+import xyz.mcnallydawes.githubmvp.data.model.local.User
+import xyz.mcnallydawes.githubmvp.data.source.user.UserRepository
+import org.mockito.Mockito.`when` as whenever
+
+class UserDetailPresenterTest {
+
+    companion object {
+        @ClassRule
+        @JvmField
+        val rxSchedulers = RxImmediateSchedulerRule()
+    }
+
+    private lateinit var presenter: UserDetailPresenter
+    @Mock private lateinit var view: UserDetailContract.View
+    @Mock private lateinit var userRepo: UserRepository
+
+    private val dummyUser = User(id = 0, avatarUrl = "avatarUrl", name = "name", username = "username", location = "location")
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        presenter = UserDetailPresenter(view, userRepo)
+    }
+
+    @Test
+    fun testConstructor() {
+        verify(view).setPresenter(presenter)
+    }
+
+    @Test
+    fun testInitialize() {
+        whenever(userRepo.get(0)).thenReturn(Observable.just(dummyUser))
+
+        presenter.initialize(0)
+        verify(view).setAvatarIv(dummyUser.avatarUrl!!)
+        verify(view).setNameTv(dummyUser.name!!)
+        verify(view).setUsernameTv(dummyUser.username!!)
+        verify(view).setLocationTv(dummyUser.location!!)
+    }
+
+    @Test
+    fun testTerminate() {
+
+    }
+
+    @Test
+    fun testOnBackBtnClicked() {
+        presenter.onBackBtnClicked()
+        verify(view).showPreviousView()
+    }
+
+}

--- a/app/src/test/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailViewTest.kt
+++ b/app/src/test/java/xyz/mcnallydawes/githubmvp/userdetail/UserDetailViewTest.kt
@@ -1,0 +1,77 @@
+package xyz.mcnallydawes.githubmvp.userdetail
+
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertTrue
+import kotlinx.android.synthetic.main.fragment_user_detail.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowToast
+import xyz.mcnallydawes.githubmvp.data.model.local.User
+import org.mockito.Mockito.`when` as whenever
+
+@RunWith(RobolectricTestRunner::class)
+class UserDetailViewTest {
+
+    private lateinit var view: UserDetailFragment
+    @Mock private lateinit var presenter: UserDetailContract.Presenter
+
+    private val dummyUser = User(id = 0, avatarUrl = "avatarUrl", name = "name", username = "username", location = "location")
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        val fragmentController = Robolectric.buildFragment(UserDetailFragment::class.java)
+
+        view = fragmentController.get()
+        view.setPresenter(presenter)
+
+        fragmentController.create().start().resume()
+    }
+
+    @Test
+    fun testSetAvatarIv() {
+        view.setAvatarIv(dummyUser.avatarUrl!!)
+    }
+
+    @Test
+    fun testSetNameTv() {
+        view.setNameTv(dummyUser.name!!)
+        assertEquals(view.nameTv.text.toString(), dummyUser.name)
+    }
+
+    @Test
+    fun testSetUsernameTv() {
+        view.setUsernameTv(dummyUser.username!!)
+        assertEquals(view.usernameTv.text.toString(), dummyUser.username)
+    }
+
+    @Test
+    fun testSetLocationTv() {
+        view.setLocationTv(dummyUser.location!!)
+        assertEquals(view.locationTv.text.toString(), dummyUser.location)
+    }
+
+    @Test
+    fun testShowPreviousView() {
+        view.showPreviousView()
+    }
+
+    @Test
+    fun testShowUserNotFoundError() {
+        view.showUserNotFoundError()
+        assertTrue(ShadowToast.showedToast("Unable to retrieve user"))
+    }
+
+    @Test
+    fun testShowErrorMessage() {
+        view.showErrorMessage("error message")
+        assertTrue(ShadowToast.showedToast("error message"))
+    }
+
+}

--- a/app/src/test/java/xyz/mcnallydawes/githubmvp/users/UsersPresenterTest.kt
+++ b/app/src/test/java/xyz/mcnallydawes/githubmvp/users/UsersPresenterTest.kt
@@ -30,8 +30,8 @@ class UsersPresenterTest {
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        whenever(userRepo.getUsers(0)).thenReturn(Single.just(arrayListOf(dummyUser)))
-        whenever(userRepo.removeAllUsers()).thenReturn(Completable.complete())
+        whenever(userRepo.getAllUsers(0)).thenReturn(Single.just(arrayListOf(dummyUser)))
+        whenever(userRepo.removeAll()).thenReturn(Completable.complete())
         presenter = UsersPresenter(view, userRepo)
     }
 

--- a/app/src/test/java/xyz/mcnallydawes/githubmvp/users/UsersViewTest.kt
+++ b/app/src/test/java/xyz/mcnallydawes/githubmvp/users/UsersViewTest.kt
@@ -12,6 +12,11 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
 import xyz.mcnallydawes.githubmvp.data.model.local.User
+import org.robolectric.shadows.ShadowApplication
+import android.content.Intent
+import xyz.mcnallydawes.githubmvp.Constants
+import xyz.mcnallydawes.githubmvp.userdetail.UserDetailActivity
+
 
 @RunWith(RobolectricTestRunner::class)
 class UsersViewTest {
@@ -99,7 +104,12 @@ class UsersViewTest {
     @Test
     fun testShowUserView() {
         view.showUserView(dummyUser)
-        assertTrue(ShadowToast.showedToast("Tapped " + dummyUser.username + "."))
+
+        val expectedIntent = Intent(view.activity, UserDetailActivity::class.java)
+        expectedIntent.putExtra(Constants.EXTRA_USER_ID, dummyUser.id)
+        val actual = ShadowApplication.getInstance().nextStartedActivity
+
+        assertEquals(expectedIntent.component, actual.component)
     }
 
     @Test


### PR DESCRIPTION
This one's a biggie:

- moved to observable return values in data sources for savea and get
- changed User variables to nullable
- added equals method to user
- wrapped web call, error is now a completion
- load local results in detail view first, call remote, save result
  to local, and update view
- added contract, fragment, activity, presenter for detail view
- launch detail view on user tap from main screen
- added user detail presenter tests
- added user detail view tests
- updated other tests for new nullable User variables

A thought on how to split this into logical parts in the future:

- write contract and empty tests first
- implement tests
- implement presenter and view
- update repository for changed behaviour and update any affected
  tests